### PR TITLE
Add naive/not validation

### DIFF
--- a/ipydatetime/datetime_widget.py
+++ b/ipydatetime/datetime_widget.py
@@ -52,10 +52,16 @@ class DatetimePicker(BaseWidget, DescriptionWidget, ValueWidget):
     min = Datetime(None, allow_none=True).tag(sync=True, **datetime_serialization)
     max = Datetime(None, allow_none=True).tag(sync=True, **datetime_serialization)
 
+    def _validate_tz(self, value):
+        if value.tzinfo is None:
+            raise TraitError('%s values needs to be timezone aware' % (self.__class__.__name__,))
+        return value
+
     @validate("value")
     def _validate_value(self, proposal):
         """Cap and floor value"""
         value = proposal["value"]
+        value = self._validate_tz(value)
         if self.min and self.min > value:
             value = max(value, self.min)
         if self.max and self.max < value:
@@ -66,6 +72,7 @@ class DatetimePicker(BaseWidget, DescriptionWidget, ValueWidget):
     def _validate_min(self, proposal):
         """Enforce min <= value <= max"""
         min = proposal["value"]
+        min = self._validate_tz(min)
         if self.max and min > self.max:
             raise TraitError("Setting min > max")
         if self.value and min > self.value:
@@ -76,6 +83,7 @@ class DatetimePicker(BaseWidget, DescriptionWidget, ValueWidget):
     def _validate_max(self, proposal):
         """Enforce min <= value <= max"""
         max = proposal["value"]
+        max = self._validate_tz(max)
         if self.min and max < self.min:
             raise TraitError("setting max < min")
         if self.value and max < self.value:
@@ -124,3 +132,8 @@ class NaiveDatetimePicker(DatetimePicker):
     max = Datetime(None, allow_none=True).tag(sync=True, **naive_serialization)
 
     _model_name = Unicode("NaiveDatetimeModel").tag(sync=True)
+
+    def _validate_tz(self, value):
+        if value.tzinfo is not None:
+            raise TraitError('%s values needs to be timezone unaware' % (self.__class__.__name__,))
+        return value

--- a/ipydatetime/tests/test_datetime.py
+++ b/ipydatetime/tests/test_datetime.py
@@ -20,72 +20,86 @@ def test_time_creation_blank():
 
 
 def test_time_creation_value():
-    t = datetime.datetime.today()
+    t = datetime.datetime.now(pytz.utc)
     w = DatetimePicker(value=t)
     assert w.value is t
 
 
 def test_time_validate_value_none():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(1442, 1, 1)
-    t_max = datetime.datetime(2056, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(1442, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(2056, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(value=t, min=t_min, max=t_max)
     w.value = None
     assert w.value is None
 
 
 def test_time_validate_value_vs_min():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(2019, 1, 1)
-    t_max = datetime.datetime(2056, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(2019, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(2056, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(min=t_min, max=t_max)
     w.value = t
     assert w.value.year == 2019
 
 
 def test_time_validate_value_vs_max():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(1664, 1, 1)
-    t_max = datetime.datetime(1994, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(1664, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(1994, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(min=t_min, max=t_max)
     w.value = t
     assert w.value.year == 1994
 
 
 def test_time_validate_min_vs_value():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(2019, 1, 1)
-    t_max = datetime.datetime(2056, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(2019, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(2056, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(value=t, max=t_max)
     w.min = t_min
     assert w.value.year == 2019
 
 
 def test_time_validate_min_vs_max():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(2112, 1, 1)
-    t_max = datetime.datetime(2056, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(2112, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(2056, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(value=t, max=t_max)
     with pytest.raises(TraitError):
         w.min = t_min
 
 
 def test_time_validate_max_vs_value():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(1664, 1, 1)
-    t_max = datetime.datetime(1994, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(1664, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(1994, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(value=t, min=t_min)
     w.max = t_max
     assert w.value.year == 1994
 
 
 def test_time_validate_max_vs_min():
-    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7)
-    t_min = datetime.datetime(1664, 1, 1)
-    t_max = datetime.datetime(1337, 1, 1)
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(1664, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(1337, 1, 1, tzinfo=pytz.utc)
     w = DatetimePicker(value=t, min=t_min)
     with pytest.raises(TraitError):
         w.max = t_max
+
+
+def test_time_validate_naive():
+    t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=pytz.utc)
+    t_min = datetime.datetime(1442, 1, 1, tzinfo=pytz.utc)
+    t_max = datetime.datetime(2056, 1, 1, tzinfo=pytz.utc)
+
+    w = DatetimePicker(value=t, min=t_min, max=t_max)
+    with pytest.raises(TraitError):
+        w.max = t_max.replace(tzinfo=None)
+    with pytest.raises(TraitError):
+        w.min = t_min.replace(tzinfo=None)
+    with pytest.raises(TraitError):
+        w.value = t.replace(tzinfo=None)
 
 
 def test_datetime_tzinfo():

--- a/ipydatetime/tests/test_naive.py
+++ b/ipydatetime/tests/test_naive.py
@@ -91,7 +91,5 @@ def test_time_validate_max_vs_min():
 def test_datetime_tzinfo():
     tz = pytz.timezone('Australia/Sydney')
     t = datetime.datetime(2002, 2, 20, 13, 37, 42, 7, tzinfo=tz)
-    w = NaiveDatetimePicker(value=t)
-    assert w.value == t
-    # tzinfo only changes upon input from user
-    assert w.value.tzinfo == tz
+    with pytest.raises(TraitError):
+        w = NaiveDatetimePicker(value=t)

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,14 @@ setup_args = dict(
         "tzlocal ; python_version<'3'",
     ],
     extras_require={
-        "test": ["pytest>=3.6", "pytest-cov", "pytest_check_links", "nbval", "pytz"],
+        "test": [
+            "pytest>=3.6",
+            "pytest-cov",
+            "pytest_check_links",
+            "nbval",
+            "pytz",
+            "coverage<5.0.0", # pin until nbval is compatible with coverage 5
+        ],
         "examples": [
             # Any requirements for the examples to run
             'pytz',


### PR DESCRIPTION
With this change, `DatetimePicker` only accepts timezone aware datetimes, and `NaiveDatetimePicker` only accepts naive datetimes.