### PR TITLE
Register NaiveDateTime Model

### DIFF
--- a/ts/src/plugin.ts
+++ b/ts/src/plugin.ts
@@ -17,6 +17,8 @@ import { TimeModel, TimeView } from './time';
 
 import { DatetimeModel, DatetimeView } from './datetime';
 
+import { NaiveDatetimeModel } from './naive';
+
 import {
   MODULE_NAME, MODULE_VERSION
 } from './version';
@@ -50,6 +52,7 @@ function activateWidgetExtension(app: Application<Widget>, registry: IJupyterWid
       TimeView,
       DatetimeModel,
       DatetimeView,
+      NaiveDatetimeModel,
     },
   });
 }


### PR DESCRIPTION
# Problem
Currently the `NaiveDateTime` frontend widget fails to load as it is not exported to the `IJupyterWidgetRegistry`.

![image](https://user-images.githubusercontent.com/3851682/89224848-0984ec80-d58e-11ea-9d44-d3745cacc686.png)

# Solution
* Added `NaiveDateTimeModel` to registry.